### PR TITLE
Importing jQuery without scheme for HTTPS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 	<meta charset="UTF-8" />
-	 <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"> 
+	 <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 	<meta name="author" content="Tobias Hahn, hahn-tobias@live.de"/>
 	<title>Wikipedia Triple View</title>
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<script type="text/javascript" src="rdfReader.js" > </script>
 	<link href="style.css" rel="stylesheet" type="text/css" />
 	<!--[if IE]>
@@ -27,8 +27,8 @@
 		<input type="button" id="readRdf" value="Read Rdf"></input><br/>
 		<input type="checkbox" id="showfulluri" value="showfulluri"/> komplette URI anzeigen
 	</form>
-	<div id="rdf"> 
-		
+	<div id="rdf">
+
 	</div>
 </div>
 </body>


### PR DESCRIPTION
When a non-HTTPS resource is included (as jQuery was) you can't use the page over HTTPS in Chrome (eg. with rawgit).